### PR TITLE
Fix VNC port forwarding

### DIFF
--- a/bin/make-access-files.py
+++ b/bin/make-access-files.py
@@ -13,7 +13,7 @@ import base64
 user_instances = {}
 auth_users = {}
 
-auth_template = 'no-agent-forwarding,no-port-forwarding,no-user-rc,no-X11-forwarding,'
+auth_template = 'no-agent-forwarding,no-user-rc,no-X11-forwarding,'
 keydir = '/root/make-vps/keys/'
 outdir = '/root/vps/'
 


### PR DESCRIPTION
Newer OpenSSH implicitly enables `no-port-forwarding` when `permitopen`
is used.