### PR TITLE
Improve error handling of make-access-files.py

### DIFF
--- a/bin/make-access-files.py
+++ b/bin/make-access-files.py
@@ -107,9 +107,12 @@ for filename in instance_list:
   try:
     with open(keydir+filename, 'r') as keyfile:
       for line in keyfile:
+        if line.rstrip('\n') == '':
+          continue
         keyline = line.rstrip('\n').split(' ')
         if len(keyline) < 3:
-          pass # non conforming line
+          print 'Non conforming line in %s : "%s"' % (keydir+filename, line)
+          continue # non conforming line
         elif not keyline[2] in auth_users:
           auth_users[keyline[2]] = { 'sshkey': (keyline[0], keyline[1]) }
         else:


### PR DESCRIPTION
Look for blank lines in keyfiles and ignore them
Print when non conforming lines are found
When non conforming lines are found, skip the line instead of continuing to try to parse it