### PR TITLE
Allow self ssh access

### DIFF
--- a/bin/sync-auth-keys.sh
+++ b/bin/sync-auth-keys.sh
@@ -4,6 +4,14 @@ source /root/make-vps/bin/vps-lib.sh
 
 /root/bin/make-access-files.py
 
-manager="`json_read /etc/make-vps.json manager`"
+if [[ $? -ne 0 ]] ; then
+  echo 'ERROR: Failed to generate access files'
+  exit 1
+fi
+
+# Add root's DSA key to the authorized_keys.
+cat /root/.ssh/id_dsa.pub >> /root/vps/authorized_keys
+
+manager="$(json_read /etc/make-vps.json manager)"
 scp /root/vps/attributes.py ${manager}:/home/vps/bin/attributes.py
 scp /root/vps/authorized_keys ${manager}:/home/vps/.ssh/authorized_keys


### PR DESCRIPTION
Add the root ssh key on the ganeti node to the command and control ssh
access file so that it can update without need for root on the console
server.