### PR TITLE
Fix Predictable network naming

### DIFF
--- a/all/tweak.sh
+++ b/all/tweak.sh
@@ -55,7 +55,7 @@ echo "PasswordAuthentication no" >> "/etc/ssh/sshd_config"
 
 # Preseed answers for grub-pc
 debconf-set-selections << 'GRUBPC'
-grub-pc grub2/linux_cmdline_default string console=tty1 console=ttyS0,115200n8
+grub-pc grub2/linux_cmdline_default string console=tty1 console=ttyS0,115200n8 net.ifnames=0
 grub-pc grub-pc/install_devices string /dev/vda
 GRUBPC
 

--- a/bin/tweak-vps.sh
+++ b/bin/tweak-vps.sh
@@ -137,7 +137,7 @@ fi
 if [ -f "${ostype_source}/netplan.TEMPLATE" ] ; then
   sed "s/TARGET_ADDRESS/${target_ip}/ ; s/TARGET_NETMASK_NUMBER/${target_netmask_number}/ ; s/TARGET_GATEWAY/${target_gateway}/" \
     "${ostype_source}/netplan.TEMPLATE" \
-    > "${target}/etc/netplan/ens5.yaml"
+    > "${target}/etc/netplan/eth0.yaml"
 fi
 
 # Fix the /etc/hosts file

--- a/debootstrap+bionic/interfaces.TEMPLATE
+++ b/debootstrap+bionic/interfaces.TEMPLATE
@@ -1,1 +1,1 @@
-# See /etc/netplan/ens5.yaml
+# See /etc/netplan/eth0.yaml

--- a/debootstrap+bionic/netplan.TEMPLATE
+++ b/debootstrap+bionic/netplan.TEMPLATE
@@ -5,7 +5,7 @@ network:
  version: 2
  renderer: networkd
  ethernets:
-   ens5:
+   eth0:
      dhcp4: no
      dhcp6: no
      addresses: [TARGET_ADDRESS/TARGET_NETMASK_NUMBER]

--- a/debootstrap+bullseye/interfaces.TEMPLATE
+++ b/debootstrap+bullseye/interfaces.TEMPLATE
@@ -6,8 +6,8 @@ auto lo
 iface lo inet loopback
 
 # The primary network interface
-auto ens5
-iface ens5 inet static
+auto eth0
+iface eth0 inet static
   address TARGET_ADDRESS
   netmask TARGET_NETMASK
   gateway TARGET_GATEWAY 

--- a/debootstrap+buster/interfaces.TEMPLATE
+++ b/debootstrap+buster/interfaces.TEMPLATE
@@ -6,8 +6,8 @@ auto lo
 iface lo inet loopback
 
 # The primary network interface
-auto ens5
-iface ens5 inet static
+auto eth0
+iface eth0 inet static
   address TARGET_ADDRESS
   netmask TARGET_NETMASK
   gateway TARGET_GATEWAY 

--- a/debootstrap+focal/interfaces.TEMPLATE
+++ b/debootstrap+focal/interfaces.TEMPLATE
@@ -1,1 +1,1 @@
-# See /etc/netplan/ens5.yaml
+# See /etc/netplan/eth0.yaml

--- a/debootstrap+focal/netplan.TEMPLATE
+++ b/debootstrap+focal/netplan.TEMPLATE
@@ -5,7 +5,7 @@ network:
  version: 2
  renderer: networkd
  ethernets:
-   ens5:
+   eth0:
      dhcp4: no
      dhcp6: no
      addresses: [TARGET_ADDRESS/TARGET_NETMASK_NUMBER]


### PR DESCRIPTION
Disable "Predictable" network naming in favor of classic eth0 naming for
VPS instances.

Signed-off-by: SuperQ <superq@gmail.com>