### PR TITLE
Update bullseye sources

### DIFF
--- a/debootstrap+bullseye/sources.list
+++ b/debootstrap+bullseye/sources.list
@@ -1,21 +1,21 @@
 ## Debian Buster sources.list
 
 ## Debian security updates:
-deb https://security.debian.org/debian-security bullseye-security main contrib non-free
-deb-src https://security.debian.org/debian-security bullseye-security main contrib non-free
+deb https://deb.debian.org/debian-security bullseye-security main contrib non-free
+deb-src https://deb.debian.org/debian-security bullseye-security main contrib non-free
 
 ## Debian.org:
-deb http://ftp.us.debian.org/debian/ bullseye main contrib non-free
-deb-src http://ftp.us.debian.org/debian/ bullseye main contrib non-free
+deb https://deb.debian.org/debian/ bullseye main contrib non-free
+deb-src https://deb.debian.org/debian/ bullseye main contrib non-free
 
 ## Updates
-deb http://ftp.us.debian.org/debian/ bullseye-updates main contrib non-free
-deb-src http://ftp.us.debian.org/debian/ bullseye-updates main contrib non-free
+deb https://deb.debian.org/debian/ bullseye-updates main contrib non-free
+deb-src https://deb.debian.org/debian/ bullseye-updates main contrib non-free
 
 ## Backports
-deb http://ftp.us.debian.org/debian/ bullseye-backports main contrib non-free
+deb https://deb.debian.org/debian/ bullseye-backports main contrib non-free
 
 ## Proposed updates
-#deb http://ftp.us.debian.org/debian/ bullseye-proposed-updates main contrib non-free
-#deb-src http://ftp.us.debian.org/debian/ bullseye-proposed-updates main contrib non-free
+#deb https://deb.debian.org/debian/ bullseye-proposed-updates main contrib non-free
+#deb-src https://deb.debian.org/debian/ bullseye-proposed-updates main contrib non-free
 


### PR DESCRIPTION
* Use https (now officially supported).
* Use deb.debian.org (Fastly CDN).

Signed-off-by: SuperQ <superq@gmail.com>