### PR TITLE
Switch debian buster sources from https to http

### DIFF
--- a/debootstrap+bullseye/sources.list
+++ b/debootstrap+bullseye/sources.list
@@ -1,21 +1,20 @@
 ## Debian Buster sources.list
 
 ## Debian security updates:
-deb https://deb.debian.org/debian-security bullseye-security main contrib non-free
-deb-src https://deb.debian.org/debian-security bullseye-security main contrib non-free
+deb http://deb.debian.org/debian-security bullseye-security main contrib non-free
+deb-src http://deb.debian.org/debian-security bullseye-security main contrib non-free
 
 ## Debian.org:
-deb https://deb.debian.org/debian/ bullseye main contrib non-free
-deb-src https://deb.debian.org/debian/ bullseye main contrib non-free
+deb http://deb.debian.org/debian/ bullseye main contrib non-free
+deb-src http://deb.debian.org/debian/ bullseye main contrib non-free
 
 ## Updates
-deb https://deb.debian.org/debian/ bullseye-updates main contrib non-free
-deb-src https://deb.debian.org/debian/ bullseye-updates main contrib non-free
+deb http://deb.debian.org/debian/ bullseye-updates main contrib non-free
+deb-src http://deb.debian.org/debian/ bullseye-updates main contrib non-free
 
 ## Backports
-deb https://deb.debian.org/debian/ bullseye-backports main contrib non-free
+deb http://deb.debian.org/debian/ bullseye-backports main contrib non-free
 
 ## Proposed updates
-#deb https://deb.debian.org/debian/ bullseye-proposed-updates main contrib non-free
-#deb-src https://deb.debian.org/debian/ bullseye-proposed-updates main contrib non-free
-
+#deb http://deb.debian.org/debian/ bullseye-proposed-updates main contrib non-free
+#deb-src http://deb.debian.org/debian/ bullseye-proposed-updates main contrib non-free


### PR DESCRIPTION
Workaround the out of date certificate bundle by using http for sources
Fixes iocoop/support#181