### PR TITLE
Improve error handling

### DIFF
--- a/bin/vps-lib.sh
+++ b/bin/vps-lib.sh
@@ -15,9 +15,9 @@ json_read() {
 
 get_instance_info() {
   target_name="$1"
-  tmpfile=$(mktemp)
-  curl -s -k "${API_URL}/instances/${target_name}" > "${tmpfile}"
+  tmpfile="$(mktemp)"
   echo "${tmpfile}"
+  curl --silent --insecure --fail "${API_URL}/instances/${target_name}" > "${tmpfile}"
 }
 
 get_nodes() {


### PR DESCRIPTION
This should handle errors a bit more gracefully by checking the result of the curl ( which caused the error output in iocoop/support#202 ) as well as trapping exits to cleanup temp files.