### PR TITLE
Add support for provisioning Ubuntu 22.04 Jammy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,11 @@ ansible-playbook site.yml --limit ganeti -t ganeti
 ```
 
 [Section of ansible code which does the deploy](https://github.com/iocoop/configs/blob/2311664e69e46b0222a2bab9ded88d0190c88bac/ansible/roles/ganeti/tasks/main.yml#L38-L41)
+
+To add a new guest OS, one that is newer than the current version of Ubuntu running
+on our ganeti hosts, you may need to create a new debootstrap script by running a command like
+this on all of the nodes
+
+```shell
+ln -sv gutsy /usr/share/debootstrap/scripts/jammy
+```

--- a/debootstrap+jammy/interfaces.TEMPLATE
+++ b/debootstrap+jammy/interfaces.TEMPLATE
@@ -1,0 +1,1 @@
+# See /etc/netplan/eth0.yaml

--- a/debootstrap+jammy/netplan.TEMPLATE
+++ b/debootstrap+jammy/netplan.TEMPLATE
@@ -1,0 +1,14 @@
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+network:
+ version: 2
+ renderer: networkd
+ ethernets:
+   eth0:
+     dhcp4: no
+     dhcp6: no
+     addresses: [TARGET_ADDRESS/TARGET_NETMASK_NUMBER]
+     gateway4: TARGET_GATEWAY
+     nameservers:
+       addresses: [8.8.8.8,8.8.4.4]

--- a/debootstrap+jammy/rc.local
+++ b/debootstrap+jammy/rc.local
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Author: Ben Kochie <ben@nerp.net>
+
+# The code below is only needed for after first boot install of some packages
+# Feel free to remove the contents
+
+if [ -f /root/.tweak-completed ] ; then
+  exit 0
+fi
+
+logger "Starting first boot tweak.sh"
+
+export PKG_LIST='ubuntu-standard ssh'
+export KERNEL_PACKAGE='linux-image-generic'
+/root/tweak.sh > /var/log/first-boot-tweak.log 2>&1
+
+if [ $? -eq 0 ] ; then
+  logger "Finished first boot package fixes, shutting down"
+  /sbin/poweroff
+else
+  logger "First boot tweak failed"
+fi

--- a/debootstrap+jammy/sources.list
+++ b/debootstrap+jammy/sources.list
@@ -1,0 +1,8 @@
+deb http://us.archive.ubuntu.com/ubuntu jammy main restricted universe multiverse
+deb-src http://us.archive.ubuntu.com/ubuntu jammy main restricted universe multiverse
+
+deb http://us.archive.ubuntu.com/ubuntu jammy-updates main restricted universe multiverse
+deb-src http://us.archive.ubuntu.com/ubuntu jammy-updates main restricted universe multiverse
+
+deb http://security.ubuntu.com/ubuntu jammy-security main restricted universe multiverse
+deb-src http://security.ubuntu.com/ubuntu jammy-security main restricted universe multiverse

--- a/etc/ganeti/instance-debootstrap/variants.list
+++ b/etc/ganeti/instance-debootstrap/variants.list
@@ -2,3 +2,4 @@ bionic
 bullseye
 buster
 focal
+jammy

--- a/etc/ganeti/instance-debootstrap/variants/jammy.conf
+++ b/etc/ganeti/instance-debootstrap/variants/jammy.conf
@@ -1,0 +1,74 @@
+# ganeti-instance-debootstrap defaults file
+
+# if you want to change from the default of installing debian stable
+# on the next instance, customize this file before the instance
+# installation
+
+# PROXY: if non-null, use this as an http(s)-proxy in order to speed
+# up non-cached installs or provide internet access if not directly
+# possible; not that if not set, debootstrap might still use a
+# system-wide proxy setting if it is exported in the ganeti-noded
+# daemon environment (but the node daemon environment is cleaned up
+# and not exported starting with Ganeti 2.5)
+#PROXY="http://10.0.2.162:8000/"
+
+# MIRROR: do not customize MIRROR if you want to be able to install
+# both debian and ubuntu, since they have different defaults; or
+# customize it before each install
+MIRROR="http://us.archive.ubuntu.com/ubuntu"
+
+# ARCH: define ARCH only if you want a different architecture than the
+# current one; the known use case is to install a 32-bit instance on a
+# 64-bit node; choose either "i386" or "amd64":
+# ARCH="i386"
+
+# SUITE: change suite to any of the ones supported by deboostrap; this
+# could be unstable, etch, etc.:
+SUITE="jammy"
+
+# EXTRA_PKGS: depending on the suite and architecture you are using, different
+# extra packages are needed for different hypervisors. For example:
+#
+# Xen, for squeeze i386:
+# EXTRA_PKGS="linux-image-xen-686,libc6-xen"
+# Xen, for wheezy i386:
+# EXTRA_PKGS="libc6-xen"
+# Xen, for squeeze amd64:
+# EXTRA_PKGS="linux-image-xen-amd64"
+# KVM, for squeeze/wheezy i386:
+# EXTRA_PKGS="acpi-support-base,console-tools,udev,linux-image-686"
+# KVM, for squeeze/wheezy amd64:
+# EXTRA_PKGS="acpi-support-base,console-tools,udev,linux-image-amd64"
+EXTRA_PKGS="acpid,language-pack-en-base"
+
+# CUSTOMIZE_DIR: a directory containing scripts to customize the installation.
+# The scripts are executed using run-parts
+# By default /etc/ganeti/instance-debootstrap/hooks
+# CUSTOMIZE_DIR="/etc/ganeti/instance-debootstrap/hooks"
+
+# GENERATE_CACHE: if set to yes (the default), create new cache files;
+# any other value will disable the generation of cache files (but they
+# will still be used if they exist)
+GENERATE_CACHE="yes"
+
+# CLEAN_CACHE: should be set to the number of days after which to
+# clean the cache; the default is 14 (two weeks); to disable cache
+# cleaning, set it to an empty value ("")
+CLEAN_CACHE=""
+
+# PARTITION_STYLE: whether and how the target device should be partitioned.
+# Allowed values:
+# 'none': just format the device, but don't partition it
+# 'msdos': install an msdos partition table on the device, with a single
+#          partition on it
+# (more styles may be added in the future)
+# The default is "msdos" from ganeti 2.0 onwards, but none if installing under
+# Ganeti 1.2 (os api version 5)
+# PARTITION_STYLE="none"
+
+# PARTITION_ALIGNMENT: the alignment of the partitions in sectors
+# (512B); this defaults to 1MiB to give grub enough space for
+# embedding and for better alignment with modern media (HDDs and
+# SSDs), feel free to increase it if your media has even bigger
+# allocation blocks
+# PARTITION_ALIGNMENT=2048


### PR DESCRIPTION
I've already made these changes manually on the g1 cluster (to validate that it works). Once this is merged I'll run ansible to do a no-op update to the g1 cluster with this new content.

I've also provisioned a new test VPS with this change running Ubuntu 22.04 Jammy and it appears good. I was able to SSH in, console in, logs looked good.

I tore it down after.