### PR TITLE
Increase geneti VPS max CPUs to 8

### DIFF
--- a/bin/make-vps.sh
+++ b/bin/make-vps.sh
@@ -13,6 +13,8 @@ fi
 SHARE_RAM_SIZE=1
 SHARE_DISK_SIZE=25
 
+MAX_CPU_COUNT=8
+
 # Get a list of available OS images from ganeti
 os_list=$(gnt-os list | tail -n+2 | xargs)
 
@@ -190,16 +192,14 @@ else
   exit 1
 fi
 
-if [ "${shares}" -ge 7 ] ; then
-  echo "INFO: Adding 4 CPUs"
-  gnt-instance modify -B vcpus=4 "${target_name}"
-elif [ "${shares}" -ge 5 ] ; then
-  echo "INFO: Adding 3 CPUs"
-  gnt-instance modify -B vcpus=3 "${target_name}"
-elif [ "${shares}" -ge 3 ] ; then
-  echo "INFO: Adding 2 CPUs"
-  gnt-instance modify -B vcpus=2 "${target_name}"
+cpu_count=$(calculate_cpu_count $shares)
+if [ "${cpu_count}" -gt "${MAX_CPU_COUNT}" ]; then
+  echo "WARNING: Clamping CPU count to max of ${MAX_CPU_COUNT}"
+  cpu_count="${MAX_CPU_COUNT}"
 fi
+
+echo "INFO: Adding ${cpu_count} CPUs"
+gnt-instance modify -B vcpus=${cpu_count} "${target_name}"
 
 echo "INFO: Activating disks"
 

--- a/bin/vps-lib.sh
+++ b/bin/vps-lib.sh
@@ -13,6 +13,12 @@ json_read() {
   python -c "import json; import sys; print json.loads(sys.stdin.read())['${var}']" < "${file}"
 }
 
+calculate_cpu_count() {
+  local shares
+  shares="$1"
+  echo $(( (shares + 1) /2 ))
+}
+
 get_instance_info() {
   target_name="$1"
   tmpfile="$(mktemp)"


### PR DESCRIPTION
Implement a generic algorithm for calculating the CPU count from the number of shares ( cpu_count = (shares + 1)/2 ) using Bash integer arithmetic.

Explicitly declare the max CPU count as a variable, and set to 8.

Fixes https://github.com/iocoop/iocoop-make-ganeti-vps/issues/36.