### PR TITLE
Add bookworm non-free-firmware

### DIFF
--- a/debootstrap+bookworm/sources.list
+++ b/debootstrap+bookworm/sources.list
@@ -1,19 +1,19 @@
 ## Debian bookworm sources.list
 
 ## Debian security updates:
-deb http://deb.debian.org/debian-security bookworm-security main contrib non-free
-deb-src http://deb.debian.org/debian-security bookworm-security main contrib non-free
+deb http://deb.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+deb-src http://deb.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
 
 ## Debian.org:
-deb http://deb.debian.org/debian/ bookworm main contrib non-free
-deb-src http://deb.debian.org/debian/ bookworm main contrib non-free
+deb http://deb.debian.org/debian/ bookworm main contrib non-free non-free-firmware
+deb-src http://deb.debian.org/debian/ bookworm main contrib non-free non-free-firmware
 
 ## Updates
-deb http://deb.debian.org/debian/ bookworm-updates main contrib non-free
-deb-src http://deb.debian.org/debian/ bookworm-updates main contrib non-free
+deb http://deb.debian.org/debian/ bookworm-updates main contrib non-free non-free-firmware
+deb-src http://deb.debian.org/debian/ bookworm-updates main contrib non-free non-free-firmware
 
 ## Backports
-deb http://deb.debian.org/debian/ bookworm-backports main contrib non-free
+deb http://deb.debian.org/debian/ bookworm-backports main contrib non-free non-free-firmware
 
 ## Proposed updates
 #deb http://deb.debian.org/debian/ bookworm-proposed-updates main contrib non-free


### PR DESCRIPTION
Debian bookworm now splits non-free into two targets.