### PR TITLE
Fix the MSP cluster name

### DIFF
--- a/bin/vps-lib.sh
+++ b/bin/vps-lib.sh
@@ -42,7 +42,7 @@ vlan_info() {
   case ${subnet} in
     # MSP01
     204.246.122)
-      expected_api_host="g0-cluster.iocoop.org"
+      expected_api_host="g0.iocoop.org"
       if [ "${host}" -ge 1 -a "${host}" -le 13 ] ; then
         vlan="virbr1000"
         netmask="255.255.255.240"


### PR DESCRIPTION
This doesn't follow the format in SCL and uses g0.iocoop.org instead