### PR TITLE
Drop the interfaces template from noble

### DIFF
--- a/debootstrap+noble/interfaces.TEMPLATE
+++ b/debootstrap+noble/interfaces.TEMPLATE
@@ -1,1 +1,0 @@
-# See /etc/netplan/eth0.yaml


### PR DESCRIPTION
Noble doesn't include `ifupdown` at all and because of this does not have an `/etc/network` directory. Drop the old interfaces template to avoid trying to create it in tweak-vps.sh.